### PR TITLE
Add support for engine thrust

### DIFF
--- a/main_window/data_handlers.py
+++ b/main_window/data_handlers.py
@@ -61,9 +61,11 @@ def plot_point(self: "MainWindow", header: packet_spec.PacketHeader, message: pa
                     if pressureId in value_labels: value_labels[pressureId].setText(f"{message.pressure} psi")
                     change_new_reading(self, message.id + 4, str(message.pressure) + " psi") #array id for pressure label is 5 - 8
                 case packet_spec.TelemetryPacketSubType.MASS:
-                    tankMass:str = "tank_mass"
-                    plots[tankMass].points = np.append(plots[tankMass].points, np.array([[message.time_since_power, message.mass]]), axis=0)
-                    plots[tankMass].data_line.setData(plots[tankMass].points)
+                    massId:str = "m" + str(message.id)
+                    plots[massId].points = np.append(plots[massId].points, np.array([[message.time_since_power, message.mass]]), axis=0)
+                    plots[massId].data_line.setData(plots[massId].points)
+                    if message.id == 1: change_new_reading(self, 4, str(message.mass) + " kg")
+                    else: change_new_reading(self, 9, str(message.mass) + " kg")
 
 def filter_data(self: "MainWindow"):
     for key in self.plots:

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -169,7 +169,7 @@ class MainWindow(QWidget):
         self.ui.tankMassPlot.getAxis("left").setTextPen(black_pen)
         self.ui.tankMassPlot.getAxis("bottom").setPen(black_pen)
         self.ui.tankMassPlot.getAxis("bottom").setTextPen(black_pen)
-        self.plots["tank_mass"] = PlotInfo(self.tank_mass_points, self.ui.tankMassPlot.plot(self.tank_mass_points, pen=red_pen))
+        self.plots["m1"] = PlotInfo(self.tank_mass_points, self.ui.tankMassPlot.plot(self.tank_mass_points, pen=red_pen))
         for marker in [self.ui.tankMassThresholdList.item(x) for x in range(self.ui.tankMassThresholdList.count())]:
             self.ui.tankMassPlot.addItem(InfiniteLine(float(marker.text()), angle=0, pen=black_pen))
 
@@ -181,7 +181,7 @@ class MainWindow(QWidget):
         self.ui.engineThrustPlot.getAxis("left").setTextPen(black_pen)
         self.ui.engineThrustPlot.getAxis("bottom").setPen(black_pen)
         self.ui.engineThrustPlot.getAxis("bottom").setTextPen(black_pen)
-        self.plots["engine_thrust"] = PlotInfo(self.engine_thrust_points, self.ui.engineThrustPlot.plot(self.engine_thrust_points, pen=red_pen))
+        self.plots["m2"] = PlotInfo(self.engine_thrust_points, self.ui.engineThrustPlot.plot(self.engine_thrust_points, pen=red_pen))
         for marker in [self.ui.engineThrustThresholdList.item(x) for x in range(self.ui.engineThrustThresholdList.count())]:
             self.ui.engineThrustPlot.addItem(InfiniteLine(float(marker.text()), angle=0, pen=black_pen))
 


### PR DESCRIPTION
This PR plots adds support for plotting engine thrust data assuming that it's sent with id 2 and tank mass is sent with id 1