### PR TITLE
Add very basic serial csv logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ venv
 # Sensor recordings and log outputs
 /recording/*
 /logs/*
+/data_csv/*

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -230,6 +230,8 @@ class MainWindow(QWidget):
         #Connect toggle button for recording data
         self.ui.recordingToggleButton.toggled.connect(self.recording_toggle_button_handler)
         self.file_out = None
+        self.csv_fieldnames = ["t","m1","m2","p1","p2","p3","p4","t1","t2","t3","status"]
+        self.csv_out = None
 
         # Init valve and sensor labels
         self.init_actuator_valve_label()

--- a/packet_spec.py
+++ b/packet_spec.py
@@ -249,6 +249,6 @@ def parse_serial_packet(data: bytes, timestamp: int, default_open_valves):
                     state = ActuatorState.OFF if bit == "0" else ActuatorState.ON
                 message = ActuatorStatePacket(timestamp, index, state)
                 packet_list.append((header, message))
-    return packet_list
+    return parsed_packet, packet_list
 
             


### PR DESCRIPTION
This PR adds a last minute change to include csv data logging. This is not the PR for issue #35 but just something to get us going. The format of the csv is as follows:
t,m1,m2,p1,p2,p3,p4,t1,t2,t2,t3,status 

The status field will be a bit string where bit _i_ indicates if actuator _i_ is energized