### PR TITLE
Add logging from UDP data source

### DIFF
--- a/main_window/logging.py
+++ b/main_window/logging.py
@@ -5,6 +5,7 @@ and saving logs
 """
 
 import pathlib
+import csv
 from typing import TYPE_CHECKING
 
 from PySide6.QtCore import QDateTime
@@ -26,3 +27,15 @@ def save_to_file(self: "MainWindow"):
 def write_to_log(self: "MainWindow", msg: str):
     cur_date_time = QDateTime.currentDateTime().toString("yyyy-MM-dd - HH:mm:ss")
     self.ui.logOutput.append(f"[{cur_date_time}]: {msg}")
+
+def create_csv_log(self: "MainWindow"):
+    self.csv_out = self.csv_dir / f"{QDateTime.currentDateTime().toString("yyyy-MM-dd_HH-mm")}.csv"
+    self.csv_dir.mkdir(parents=True, exist_ok=True)
+    with open(self.csv_out, "w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
+        writer.writeheader()
+
+def write_to_csv_log(self: "MainWindow", packet_dict: dict):
+    with open(self.csv_out, "a", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
+        writer.writerow(packet_dict)   

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -1,5 +1,6 @@
 # This Python file uses the following encoding: utf-8
 from dataclasses import dataclass
+from pathlib import Path
 
 from PySide6.QtWidgets import QWidget, QLabel, QMessageBox
 from PySide6.QtCore import QTimer, Qt, QMutex, QPoint
@@ -79,7 +80,7 @@ class MainWindow(QWidget):
         process_data, turn_off_valve, turn_on_valve, decrease_heartbeat, reset_heartbeat_timeout
     from .recording_and_playback import recording_toggle_button_handler, \
         open_file_button_handler, display_previous_data
-    from .logging import save_to_file, write_to_log
+    from .logging import save_to_file, write_to_log, create_csv_log, write_to_csv_log
     from .config import load_config, save_config, add_pressure_threshold_handler, \
     add_temperature_threshold_handler, add_tank_mass_threshold_handler, add_engine_thrust_threshold_handler
 
@@ -236,7 +237,8 @@ class MainWindow(QWidget):
         #Connect toggle button for recording data
         self.ui.recordingToggleButton.toggled.connect(self.recording_toggle_button_handler)
         self.file_out = None
-        self.csv_fieldnames = ["t","m1","m2","p1","p2","p3","p4","t1","t2","t3","status"]
+        self.csv_dir = Path("data_csv")
+        self.csv_fieldnames = ["t","m1","m2","p1","p2","p3","p4","p5","p6","t1","t2","t3","t4","status"]
         self.csv_out = None
 
         # Init valve and sensor labels


### PR DESCRIPTION
Closes #35 

This PR adds plaintext data logging for data received over UDP. Because data for each sensor is sent in a separate packet, a new line is written to the CSV file on each packet received. This also reconciles some other system restrictions. No status of actuators is logged in this csv file, but that data can be obtained from the general log.