### PR TITLE
Change how data is written to CSV

### DIFF
--- a/main_window/csv_writer.py
+++ b/main_window/csv_writer.py
@@ -1,0 +1,60 @@
+import threading
+import csv
+from pathlib import Path
+from datetime import datetime
+
+# I'm aware that this is a little over-engineered but this avoids any possibility of
+# data loss by swapping buffers and also organizes data nicely into csvs
+class CSVWriter:
+  def __init__(self, csv_fieldnames):
+    self.dictbuffer1 = {}
+    self.dictbuffer2 = {}
+    self.activebuffer = self.dictbuffer1
+    self.activebufferind = 1
+    self.csv_dir = Path("data_csv")
+    self.csv_out = None
+    self.csv_fieldnames = csv_fieldnames
+
+  def add_timed_measurements(self, time: int, sensor_readings: dict):
+    # Only try to flush the buffer when receiving a new timestamp
+    if str(time) not in self.activebuffer:
+      if len(self.activebuffer) >= 100:
+        # Start buffer flush thread if buffer gets full
+        flush_thread = threading.Thread(target=self.flush_dict_buffer, args=(self.activebufferind,))
+        flush_thread.start()
+
+        if self.activebufferind == 1:        
+          self.activebuffer = self.dictbuffer2
+          self.activebufferind = 2
+        elif self.activebufferind == 2:
+          self.activebuffer = self.dictbuffer1
+          self.activebufferind = 1
+
+      self.activebuffer[str(time)] = {}
+    
+    self.activebuffer[str(time)].update(sensor_readings)
+
+  def create_csv_log(self):
+    self.csv_out = self.csv_dir / f"{datetime.now().strftime('%Y-%m-%d_%H-%M')}.csv"
+    self.csv_dir.mkdir(parents=True, exist_ok=True)
+    with open(self.csv_out, "w", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
+        writer.writeheader()
+
+  def flush_dict_buffer(self, bufferind):
+    if bufferind == 1:
+      with open(self.csv_out, "a", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
+        for key in self.dictbuffer1:
+          temp = {"t": key}
+          temp.update(self.dictbuffer1[key])
+          writer.writerow(temp)
+      self.dictbuffer1 = {}
+    elif bufferind == 2:
+      with open(self.csv_out, "a", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
+        for key in self.dictbuffer2:
+          temp = {"t": key}
+          temp.update(self.dictbuffer2[key])
+          writer.writerow(temp)
+      self.dictbuffer2 = {}

--- a/main_window/logging.py
+++ b/main_window/logging.py
@@ -27,15 +27,4 @@ def save_to_file(self: "MainWindow"):
 def write_to_log(self: "MainWindow", msg: str):
     cur_date_time = QDateTime.currentDateTime().toString("yyyy-MM-dd - HH:mm:ss")
     self.ui.logOutput.append(f"[{cur_date_time}]: {msg}")
-
-def create_csv_log(self: "MainWindow"):
-    self.csv_out = self.csv_dir / f"{QDateTime.currentDateTime().toString("yyyy-MM-dd_HH-mm")}.csv"
-    self.csv_dir.mkdir(parents=True, exist_ok=True)
-    with open(self.csv_out, "w", newline="") as file:
-        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
-        writer.writeheader()
-
-def write_to_csv_log(self: "MainWindow", packet_dict: dict):
-    with open(self.csv_out, "a", newline="") as file:
-        writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
-        writer.writerow(packet_dict)   
+    

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -79,9 +79,10 @@ class MainWindow(QWidget):
         process_data, turn_off_valve, turn_on_valve, decrease_heartbeat, reset_heartbeat_timeout
     from .recording_and_playback import recording_toggle_button_handler, \
         open_file_button_handler, display_previous_data
-    from .logging import save_to_file, write_to_log, create_csv_log, write_to_csv_log
+    from .logging import save_to_file, write_to_log
     from .config import load_config, save_config, add_pressure_threshold_handler, \
     add_temperature_threshold_handler, add_tank_mass_threshold_handler, add_engine_thrust_threshold_handler
+    from .csv_writer import CSVWriter
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -236,9 +237,7 @@ class MainWindow(QWidget):
         #Connect toggle button for recording data
         self.ui.recordingToggleButton.toggled.connect(self.recording_toggle_button_handler)
         self.file_out = None
-        self.csv_dir = Path("data_csv")
-        self.csv_fieldnames = ["t","p0","p1","p2","p3","p4","p5","t0","t1","t2","t3","m0","th0","status"]
-        self.csv_out = None
+        self.csv_writer = self.CSVWriter(["t","p0","p1","p2","p3","p4","p5","t0","t1","t2","t3","m0","th0","status"])
 
         # Init valve and sensor labels
         self.init_actuator_valve_label()

--- a/main_window/serial.py
+++ b/main_window/serial.py
@@ -39,6 +39,7 @@ def serial_connection_button_handler(self: "MainWindow"):
       self.enable_serial_config()
       self.enable_udp_config()
       self.update_serial_connection_display(SerialConnectionStatus.NOT_CONNECTED)
+      self.csv_writer.flush_dict_buffer()
          
 def refresh_serial_button_handler(self: "MainWindow"):
    self.ui.serialPortDropdown.clear()

--- a/main_window/serial.py
+++ b/main_window/serial.py
@@ -32,7 +32,7 @@ def serial_connection_button_handler(self: "MainWindow"):
         self.disable_serial_config(disable_btn=False)
         self.disable_udp_config(disable_btn=True)
         self.update_serial_connection_display(SerialConnectionStatus.CONNECTED)
-        self.create_csv_log()
+        self.csv_writer.create_csv_log()
     else:
       self.serialPort.close()
       self.write_to_log("Serial connection was closed")
@@ -77,7 +77,7 @@ def serial_receive_data(self: "MainWindow"):
       self.serialTimestamp = round(self.serialTimestamp + 0.1, 2)
       packet_dict = dataclasses.asdict(parsed_packet)
       packet_dict["t"] = self.serialTimestamp
-      self.write_to_csv_log(packet_dict) 
+      self.csv_writer.add_timed_measurements(packet_dict) 
 
 # Any errors with the socket should be handled here and logged
 def serial_on_error(self: "MainWindow"):

--- a/main_window/udp.py
+++ b/main_window/udp.py
@@ -64,7 +64,7 @@ def udp_connection_button_handler(self: "MainWindow"):
             self.disable_serial_config(disable_btn=True)
             self.update_udp_connection_display(UDPConnectionStatus.CONNECTED)
 
-            self.create_csv_log()
+            self.csv_writer.create_csv_log()
         else:
             self.write_to_log(f"Unable to join multicast group at IP address: {mcast_addr}, port: {mcast_port}")
     else:
@@ -96,17 +96,19 @@ def udp_receive_socket_data(self: "MainWindow"):
         self.process_data(header, message)
 
         # Write data to csv here
-        packet_dict = { "t": message.time_since_power }
+        packet_dict = {}
         match header.sub_type:
             case packet_spec.TelemetryPacketSubType.TEMPERATURE:
                 packet_dict["t" + str(message.id)] = message.temperature
-                self.write_to_csv_log(packet_dict)
+                self.csv_writer.add_timed_measurements(message.time_since_power, packet_dict)
             case packet_spec.TelemetryPacketSubType.PRESSURE:
                 packet_dict["p" + str(message.id)] = message.pressure
-                self.write_to_csv_log(packet_dict)
+                self.csv_writer.add_timed_measurements(message.time_since_power, packet_dict)
             case packet_spec.TelemetryPacketSubType.MASS:
                 packet_dict["m" + str(message.id)] = message.mass 
-                self.write_to_csv_log(packet_dict)
+                self.csv_writer.add_timed_measurements(message.time_since_power, packet_dict)
+            case packet_spec.TelemetryPacketSubType.THRUST:
+                self.csv_writer.add_timed_measurements(message.time_since_power, packet_dict)
 
         #If we want to recording data
         if self.ui.recordingToggleButton.isChecked():

--- a/main_window/udp.py
+++ b/main_window/udp.py
@@ -129,5 +129,6 @@ def udp_on_disconnected(self: "MainWindow"):
     self.enable_udp_config()
     self.enable_serial_config()
     self.update_udp_connection_display(UDPConnectionStatus.NOT_CONNECTED)
+    self.csv_writer.flush_dict_buffer()
     if self.file_out:
         self.file_out.close()


### PR DESCRIPTION
There's an annoyance with data is currently being logged as a csv. We receive packets for sensors individually, most of the time they arrive for the same timestamp. With the way data is currently being logged, each new sensor measurement is being put on a new line within the same csv file even though, it was collected at the same time as those that came before it. 

To fix this, I've implemented a CSVWriter object that stores data received in one of two dictionary buffers. The keys of these dictionaries are timestamps, and the values are dictionaries containing sensor ids and the values read from those sensors at the timestamp. When the buffer we're currently writing to becomes too big (~100 timestamp values), a thread is spawned that "flushes" the dictionary to a csv file using the same csv DictWriter in the background. The dictionary that is then used to store data is then swapped to the second buffer while the other is cleared. 

While it's admittedly a little over-engineered, this ensures that no data is lost and data is being consistently logged and in an organized format.