### PR TITLE
Save csv button

### DIFF
--- a/main_window/csv_writer.py
+++ b/main_window/csv_writer.py
@@ -13,8 +13,8 @@ class CSVWriter:
     self.activebufferind = 1
     self.csv_fieldnames = csv_fieldnames
     self.buffer_size = buffer_size
-    self.csv_dir = Path(dir)
-    self.csv_out = None
+    self.csv_dir: Path = Path(dir)
+    self.csv_out: Path = None
 
   def add_timed_measurements(self, time: int, sensor_readings: dict):
     # Only try to flush the buffer when receiving a new timestamp
@@ -44,6 +44,21 @@ class CSVWriter:
     # Start buffer flush thread if buffer gets full
     flush_thread = threading.Thread(target=self.__flush_dict_buffer, args=(self.activebufferind,))
     flush_thread.start()
+
+  def save_and_swap_csv(self, new_name: str = None):
+    if new_name: self.csv_out.rename(f"{self.csv_dir}/{new_name}.csv")
+    
+    if self.activebufferind == 1:        
+      self.activebuffer = self.dictbuffer2
+    elif self.activebufferind == 2:
+      self.activebuffer = self.dictbuffer1
+
+    self.flush()
+
+    if self.activebufferind == 1:        
+      self.activebufferind = 2
+    elif self.activebufferind == 2:
+      self.activebufferind = 1
 
   # Should not be called outside of flush
   def __flush_dict_buffer(self, bufferind):

--- a/main_window/csv_writer.py
+++ b/main_window/csv_writer.py
@@ -40,10 +40,13 @@ class CSVWriter:
         writer = csv.DictWriter(file, fieldnames=self.csv_fieldnames)
         writer.writeheader()
 
-  def flush(self):
+  def flush(self, _async: bool = True):
     # Start buffer flush thread if buffer gets full
-    flush_thread = threading.Thread(target=self.__flush_dict_buffer, args=(self.activebufferind,))
-    flush_thread.start()
+    if _async:
+      flush_thread = threading.Thread(target=self.__flush_dict_buffer, args=(self.activebufferind,))
+      flush_thread.start()
+    else:
+      self.__flush_dict_buffer(self.activebufferind)
 
   def save_and_swap_csv(self, new_name: str = None):
     if new_name: self.csv_out.rename(f"{self.csv_dir}/{new_name}.csv")

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -268,7 +268,6 @@ class MainWindow(QWidget):
 
             self.data_csv_writer.flush(_async=False)
             self.state_csv_writer.flush(_async=False)
-            print("flushing buffers")
             event.accept()
         else:
             event.ignore()

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -1,7 +1,7 @@
 # This Python file uses the following encoding: utf-8
 from dataclasses import dataclass
 
-from PySide6.QtWidgets import QWidget, QLabel, QMessageBox
+from PySide6.QtWidgets import QWidget, QLabel, QMessageBox, QInputDialog
 from PySide6.QtCore import QTimer, Qt, QMutex
 from PySide6.QtNetwork import QUdpSocket, QAbstractSocket
 from PySide6.QtSerialPort import QSerialPort, QSerialPortInfo
@@ -228,7 +228,10 @@ class MainWindow(QWidget):
         self.ui.serialConnectButton.clicked.connect(self.serial_connection_button_handler)
         self.ui.serialRefreshButton.clicked.connect(self.refresh_serial_button_handler)
 
-        # Open new file heandler
+        # Save CSV button handler
+        self.ui.saveCsvButton.clicked.connect(self.save_csv_button_handler)
+
+        # Open raw data file button handler
         self.ui.openFileButton.clicked.connect(self.open_file_button_handler)
 
         # Connect toggle button for recording data
@@ -259,11 +262,13 @@ class MainWindow(QWidget):
             if self.padUDPSocket.state() == QAbstractSocket.SocketState.ConnectedState:
                 self.padUDPSocket.disconnectFromHost()
                 self.padUDPSocket.waitForDisconnected()
-                self.data_csv_writer.flush()
 
             if self.serialPort.isOpen():
                 self.serialPort.close()
 
+            self.data_csv_writer.flush(_async=False)
+            self.state_csv_writer.flush(_async=False)
+            print("flushing buffers")
             event.accept()
         else:
             event.ignore()
@@ -345,3 +350,8 @@ class MainWindow(QWidget):
             case self.SerialConnectionStatus.NOT_CONNECTED:
                 self.ui.serialConnStatusLabel.setText("Not connected")
                 self.ui.serialConnStatusLabel.setStyleSheet("background-color: rgb(0, 85, 127);")
+
+    def save_csv_button_handler(self):
+        new_name, _ = QInputDialog.getText(self, "Save CSV file", "Enter name to save CSV file as")
+        self.data_csv_writer.save_and_swap_csv(new_name)
+        self.state_csv_writer.save_and_swap_csv(new_name)

--- a/main_window/ui/form.ui
+++ b/main_window/ui/form.ui
@@ -55,7 +55,7 @@
        <item>
         <layout class="QHBoxLayout" name="controlLayout" stretch="2,1,0">
          <item>
-          <layout class="QVBoxLayout" name="mainLayout" stretch="0,0,0,0">
+          <layout class="QVBoxLayout" name="mainLayout" stretch="0,0,0,0,0">
            <item>
             <widget class="QLabel" name="logoLabel">
              <property name="sizePolicy">
@@ -93,14 +93,21 @@
            <item>
             <widget class="QPushButton" name="showPIDButton">
              <property name="text">
-              <string>Show PID </string>
+              <string>Open PID window</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="saveCsvButton">
+             <property name="text">
+              <string>Save current CSV data</string>
              </property>
             </widget>
            </item>
            <item>
             <widget class="QPushButton" name="openFileButton">
              <property name="text">
-              <string>Open previous data</string>
+              <string>Open raw data file</string>
              </property>
             </widget>
            </item>

--- a/main_window/ui/ui_form.py
+++ b/main_window/ui/ui_form.py
@@ -68,6 +68,11 @@ class Ui_Widget(object):
 
         self.mainLayout.addWidget(self.showPIDButton)
 
+        self.saveCsvButton = QPushButton(self.telemetryTab)
+        self.saveCsvButton.setObjectName(u"saveCsvButton")
+
+        self.mainLayout.addWidget(self.saveCsvButton)
+
         self.openFileButton = QPushButton(self.telemetryTab)
         self.openFileButton.setObjectName(u"openFileButton")
 
@@ -601,8 +606,9 @@ class Ui_Widget(object):
         Widget.setToolTip("")
 #endif // QT_CONFIG(tooltip)
         self.logoLabel.setText("")
-        self.showPIDButton.setText(QCoreApplication.translate("Widget", u"Show PID ", None))
-        self.openFileButton.setText(QCoreApplication.translate("Widget", u"Open previous data", None))
+        self.showPIDButton.setText(QCoreApplication.translate("Widget", u"Open PID window", None))
+        self.saveCsvButton.setText(QCoreApplication.translate("Widget", u"Save current CSV data", None))
+        self.openFileButton.setText(QCoreApplication.translate("Widget", u"Open raw data file", None))
         self.recordingToggleButton.setText(QCoreApplication.translate("Widget", u"Recording raw data", None))
         self.udpConnLabel.setText(QCoreApplication.translate("Widget", u"UDP connection status:", None))
         self.udpConnStatusLabel.setText(QCoreApplication.translate("Widget", u"Not connected", None))


### PR DESCRIPTION
Closes #93 

This PR adds a button to the new UI that when pressed will swap prompt the user to name the active csv file. This will rename the active csv file and swap the csv writer class to a new one, flushing all the current measurements without data loss. It also fixes a bug where csv's weren't being flushed on app close.