### PR TITLE
Have disconnection be more noticeable with flashing light

### DIFF
--- a/main_window/data_handlers.py
+++ b/main_window/data_handlers.py
@@ -135,10 +135,10 @@ def update_control_client_display(self: "MainWindow", status: packet_spec.IPConn
             self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(0, 255, 0); color: black;")
         case packet_spec.IPConnectionStatus.RECONNECTING:
             self.ui.ccConnStatusLabel.setText("Reconnecting")
-            self.disconnect_status_timer.start()
+            self.disconnect_status_timer.start(self.disconnect_status_interval)
         case packet_spec.IPConnectionStatus.DISCONNECTED:
             self.ui.ccConnStatusLabel.setText("Connection lost")
-            self.disconnect_status_timer.start()
+            self.disconnect_status_timer.start(self.disconnect_status_interval)
         case packet_spec.IPConnectionStatus.NOT_CONNECTED:
             self.disconnect_status_timer.stop()
             self.ui.ccConnStatusLabel.setText("Not connected")

--- a/main_window/data_handlers.py
+++ b/main_window/data_handlers.py
@@ -130,15 +130,17 @@ def update_pad_server_display(self: "MainWindow", status: packet_spec.IPConnecti
 def update_control_client_display(self: "MainWindow", status: packet_spec.IPConnectionStatus):
     match status:
         case packet_spec.IPConnectionStatus.CONNECTED:
+            self.disconnect_status_timer.stop()
             self.ui.ccConnStatusLabel.setText("Connected")
             self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(0, 255, 0); color: black;")
         case packet_spec.IPConnectionStatus.RECONNECTING:
             self.ui.ccConnStatusLabel.setText("Reconnecting")
-            self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(255, 128, 0); color: black;")
+            self.disconnect_status_timer.start()
         case packet_spec.IPConnectionStatus.DISCONNECTED:
             self.ui.ccConnStatusLabel.setText("Connection lost")
-            self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(255, 80, 80); color: black;")
+            self.disconnect_status_timer.start()
         case packet_spec.IPConnectionStatus.NOT_CONNECTED:
+            self.disconnect_status_timer.stop()
             self.ui.ccConnStatusLabel.setText("Not connected")
             self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(0, 85, 127); color: white")
 
@@ -213,3 +215,10 @@ def decrease_heartbeat(self: "MainWindow"):
         self.update_control_client_display(packet_spec.IPConnectionStatus.DISCONNECTED)
         self.write_to_log(f"Heartbeat not found for {abs(self.heartbeat_timeout) + 1} seconds")
     self.heartbeat_mutex.unlock()
+
+def flash_disconnect_label(self: "MainWindow"):
+    if self.disconnect_count % 2 == 0:
+        self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(255, 80, 80); color: black;")
+    else:
+        self.ui.ccConnStatusLabel.setStyleSheet("background-color: rgb(0, 255, 255); color: white;")
+    self.disconnect_count += 1

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -67,7 +67,8 @@ class MainWindow(QWidget):
         refresh_serial_button_handler, serial_receive_data, serial_on_error
     from .data_handlers import plot_point, filter_data, update_serial_connection_display, \
         update_pad_server_display, update_control_client_display, process_data, decrease_heartbeat, \
-        reset_heartbeat_timeout, calculate_new_average, update_arming_state, update_continuity_state
+        reset_heartbeat_timeout, calculate_new_average, update_arming_state, update_continuity_state, \
+        flash_disconnect_label
     from .recording_and_playback import recording_toggle_button_handler, open_file_button_handler
     from .logging import save_to_file, write_to_log, display_popup
     from .config import load_config, save_config, add_default_open_valve_handler, pressure_data_display_change_handler, \
@@ -274,6 +275,12 @@ class MainWindow(QWidget):
         self.heartbeat_interval = 1000
         self.heartbeat_timer = QTimer(self)
         self.heartbeat_timer.timeout.connect(self.decrease_heartbeat)
+
+        # QTimer to flash the connection status label
+        self.disconnect_status_interval = 500
+        self.disconnect_count = 0
+        self.disconnect_status_timer = QTimer(self)
+        self.disconnect_status_timer.timeout.connect(self.flash_disconnect_label)
 
         # Button handlers
 


### PR DESCRIPTION
Closes #111 

This PR adds a timer that starts when the control client is disconnected to flash the display colors.