### PR TITLE
Fix recording and playback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ venv
 .venv
 
 # Sensor recordings and log outputs
-/recording/*
+/recordings/*
 /logs/*
 /data_csv/*
 /valves_csv/*

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -323,7 +323,15 @@ class MainWindow(QWidget):
         self.timer_controller.flash_cc_disconnect_label_s.connect(self.telem_vis_manager.flash_cc_label)
         self.timer_controller.update_pad_server_display_s.connect(self.telem_vis_manager.update_ps_conn_status_label)
         self.timer_controller.update_control_client_display_s.connect(self.telem_vis_manager.update_cc_conn_status_label)
+        self.timer_controller.playback_packet.connect(self.playback_manager.playback_packet)
         self.timer_controller.log_ready.connect(self.log_manager.write_to_log)
+
+        self.playback_manager.parsed_packet_ready.connect(self.data_handler.process_packet)
+        self.playback_manager.playback_started.connect(self.timer_controller.start_playback_timer)
+        self.playback_manager.playback_started.connect(self.timer_controller.start_data_filter_timer)
+        self.playback_manager.playback_ended.connect(self.timer_controller.stop_playback_timer)
+        self.playback_manager.playback_ended.connect(self.timer_controller.stop_data_filter_timer)
+        self.playback_manager.log_ready.connect(self.log_manager.write_to_log)
 
         ### Button and associated signal handlers ###
         # In some cases, it was easier to have some signals connect to a UI manager function
@@ -340,7 +348,7 @@ class MainWindow(QWidget):
 
         # Handlers for recording and replaying data
         self.raw_data_file_out = None
-        # self.ui.openFileButton.clicked.connect(self.open_file_button_handler)
+        self.ui.openFileButton.clicked.connect(self.playback_manager.open_file_button_handler)
         # self.ui.recordingToggleButton.toggled.connect(self.recording_toggle_button_handler)
 
         # Switching PID in PID window

--- a/main_window/main_window.py
+++ b/main_window/main_window.py
@@ -37,6 +37,7 @@ from .timer_controller import TimerController
 from .labels import *
 from .logging import LogManager
 from .config import ConfigManager
+from .recording_and_playback import PlaybackManager
 
 class PIDWindow(QWidget):
     def __init__(self):
@@ -243,6 +244,7 @@ class MainWindow(QWidget):
         self.telem_vis_manager = TelemVisManager(self.sensors, self.valves, self.conn_status_labels, self.hybrid_state_labels, self.plot_data)
         self.ui_manager = UIManager(self.ui)
         self.timer_controller = TimerController()
+        self.playback_manager = PlaybackManager()
 
         self.data_csv_writer = CSVWriter(["t","p1","p2","p3","p4","p5","p6","t1","t2","t3","t4","m1","th1","status","Continuity"], 100, "data_csv")
         self.state_csv_writer = CSVWriter(["t","Igniter","XV-1","XV-2","XV-3","XV-4","XV-5","XV-6","XV-7","XV-8","XV-9","XV-10","XV-11","XV-12","Quick disconnect","Dump valve","Arming state","Continuity"], 0, "valves_csv")
@@ -272,6 +274,7 @@ class MainWindow(QWidget):
         self.udp_controller.multicast_group_joined.connect(self.timer_controller.start_data_filter_timer)
         self.udp_controller.multicast_group_joined.connect(self.timer_controller.start_heartbeat_timer)
         self.udp_controller.multicast_group_joined.connect(lambda: self.telem_vis_manager.update_ps_conn_status_label(packet_spec.IPConnectionStatus.CONNECTED))
+        self.udp_controller.multicast_group_joined.connect(self.playback_manager.create_recording_file)
         self.udp_controller.multicast_group_joined.connect(self.data_csv_writer.create_csv_log)
         self.udp_controller.multicast_group_joined.connect(self.state_csv_writer.create_csv_log)
         
@@ -292,6 +295,7 @@ class MainWindow(QWidget):
         self.udp_controller.multicast_group_disconnected.connect(self.data_csv_writer.flush)
         self.udp_controller.multicast_group_disconnected.connect(self.state_csv_writer.flush)
 
+        self.udp_controller.data_received.connect(self.playback_manager.on_data_received)
         self.udp_controller.parsed_packet_ready.connect(self.data_handler.process_packet)
         self.udp_controller.easter_egg_opened.connect(self.ui_manager.deploy_easter_egg)
         self.udp_controller.easter_egg_closed.connect(self.ui_manager.hide_easter_egg)

--- a/main_window/recording_and_playback.py
+++ b/main_window/recording_and_playback.py
@@ -7,8 +7,8 @@ Should only be imported by main_window.py
 import pathlib
 from io import BufferedWriter
 
-from PySide6.QtWidgets import QFileDialog
-from PySide6.QtCore import QDateTime, QObject, Slot, Signal
+from PySide6.QtWidgets import QWidget, QFileDialog
+from PySide6.QtCore import QDateTime, QObject, Slot, Signal, QFile, QDataStream, QIODevice
 
 import packet_spec
 
@@ -22,7 +22,8 @@ class PlaybackManager(QObject):
     def __init__(self):
         self.playback_ptr = 0
         self.buffered_writer = None
-        self.data_buffer = None
+        self.data_buffer: QFile = None
+        self.stream: QDataStream = None
         super().__init__()
 
     @Slot()
@@ -53,24 +54,20 @@ class PlaybackManager(QObject):
         # signal doesn't create one
         if file_path:
             self.log_ready.emit(f"Reading data from {file_path}")
-            with open(file_path, "rb") as file:
-                self.playback_ptr = 0
-                self.data_buffer = file.read()
-                self.playback_started.emit()
-            self.log_ready.emit("Data loaded")
+            self.data_buffer = QFile(file_path)
+            self.data_buffer.open(QIODevice.OpenModeFlag.ReadOnly)
+            self.stream = QDataStream(self.data_buffer)
+            self.playback_started.emit()
 
     @Slot()
     def playback_packet(self):
-        data_len = len(self.data_buffer)
-        if self.playback_ptr < data_len:
-            header = self.data_buffer[self.playback_ptr : self.playback_ptr + 2]
-            self.playback_ptr += 2
+        if self.stream.atEnd():
+            self.playback_ended.emit()
+        else:
+            header = self.stream.readRawData(2)
             data_header = packet_spec.parse_packet_header(header)
             message_bytes_length = packet_spec.packet_message_bytes_length(data_header)
-            message = self.data_buffer[self.playback_ptr : self.playback_ptr + message_bytes_length]
+            message = self.stream.readRawData(message_bytes_length)
             data_message = packet_spec.parse_packet_message(data_header, message)
             self.playback_ptr += message_bytes_length
             self.parsed_packet_ready.emit(data_header, data_message)
-        else:
-            self.playback_ended.emit()
-

--- a/main_window/timer_controller.py
+++ b/main_window/timer_controller.py
@@ -20,6 +20,7 @@ class TimerController(QObject):
    flash_cc_disconnect_label_s = Signal()
    update_pad_server_display_s = Signal(packet_spec.IPConnectionStatus)
    update_control_client_display_s = Signal(packet_spec.IPConnectionStatus)
+   playback_packet = Signal()
    log_ready = Signal(str)
 
    def __init__(self):
@@ -47,6 +48,10 @@ class TimerController(QObject):
       # QTimer to flash the control client connection status label
       self.cc_disconnect_status_timer = QTimer(self)
       self.cc_disconnect_status_timer.timeout.connect(self.flash_cc_disconnect_label_s.emit)
+
+      self.playback_interval = 50
+      self.playback_timer = QTimer(self)
+      self.playback_timer.timeout.connect(self.playback_packet.emit)
 
    @Slot()
    def start_data_filter_timer(self):
@@ -120,3 +125,13 @@ class TimerController(QObject):
    def stop_cc_disconnect_flash_timer(self):
       if self.cc_disconnect_status_timer.isActive():
          self.cc_disconnect_status_timer.stop()
+
+   @Slot()
+   def start_playback_timer(self):
+      if not self.playback_timer.isActive():
+         self.playback_timer.start(0.1)
+
+   @Slot()
+   def stop_playback_timer(self):
+      if self.playback_timer.isActive():
+         self.playback_timer.stop()

--- a/main_window/udp.py
+++ b/main_window/udp.py
@@ -26,6 +26,7 @@ class UDPController(QObject):
     # signal but for now we're using these
     multicast_group_joined = Signal() # Emitted whenever a multicast group is joined 
     multicast_group_disconnected = Signal() # Emitted whenever we leave the multicast group
+    data_received = Signal(bytes)
     parsed_packet_ready = Signal(packet_spec.PacketHeader, packet_spec.PacketMessage) # Emitted whenever a packet has been received and parsed 
     easter_egg_opened = Signal() # Emitted when were bored
     easter_egg_closed = Signal() # Emitted when we have to lock in
@@ -83,6 +84,7 @@ class UDPController(QObject):
                 self.padUDPSocket.pendingDatagramSize()
             )
             data = datagram.data()
+            self.data_received.emit(data)
 
             # Process all packets in the datagram
             ptr = 0
@@ -101,10 +103,6 @@ class UDPController(QObject):
                 # Parse and process the message
                 message = packet_spec.parse_packet_message(header, message_bytes)
                 self.parsed_packet_ready.emit(header, message)
-
-                # #If we want to recording data
-                # if self.ui.recordingToggleButton.isChecked():
-                #     self.raw_data_file_out.write(datagram)
 
     def join_multicast_group(self, mcast_addr: str, mcast_port: str):
         multicast_group = QHostAddress(mcast_addr)


### PR DESCRIPTION
This PR refactors the recording and playback module into the RecordingManager class that contains mostly the same functionality. Instead of manually writing data to a dump file, the UDPManager class now emits a signal with the received bytes that is handled by the RecordingManager class. The RecordingManager class uses a BufferedWriter object to buffer writes to file storage.

Raw packets are stored as dump files and can be played back.

For playback, QDataStreams are used to mimic the UDP data stream and a timer is used to simulate packets being received.